### PR TITLE
Temporary SELinux changes until new packages are released

### DIFF
--- a/elements/selinux-package-updates/install.d/00-update-selinux-policy-packages
+++ b/elements/selinux-package-updates/install.d/00-update-selinux-policy-packages
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eux
+
+sudo yum -y install https://kojipkgs.fedoraproject.org//packages/selinux-policy/3.12.1/175.fc20/noarch/selinux-policy-3.12.1-175.fc20.noarch.rpm https://kojipkgs.fedoraproject.org//packages/selinux-policy/3.12.1/175.fc20/noarch/selinux-policy-targeted-3.12.1-175.fc20.noarch.rpm

--- a/elements/swift-package-updates/install.d/00-update-swift-packages
+++ b/elements/swift-package-updates/install.d/00-update-swift-packages
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eux
+
+sudo yum -y install https://kojipkgs.fedoraproject.org//packages/openstack-swift/1.13.1/4.fc21/noarch/openstack-swift-1.13.1-4.fc21.noarch.rpm
+sudo yum -y install https://kojipkgs.fedoraproject.org//packages/openstack-swift/1.13.1/4.fc21/noarch/openstack-swift-account-1.13.1-4.fc21.noarch.rpm
+sudo yum -y install https://kojipkgs.fedoraproject.org//packages/openstack-swift/1.13.1/4.fc21/noarch/openstack-swift-container-1.13.1-4.fc21.noarch.rpm
+sudo yum -y install https://kojipkgs.fedoraproject.org//packages/openstack-swift/1.13.1/4.fc21/noarch/openstack-swift-doc-1.13.1-4.fc21.noarch.rpm
+sudo yum -y install https://kojipkgs.fedoraproject.org//packages/openstack-swift/1.13.1/4.fc21/noarch/openstack-swift-object-1.13.1-4.fc21.noarch.rpm
+sudo yum -y install https://kojipkgs.fedoraproject.org//packages/openstack-swift/1.13.1/4.fc21/noarch/openstack-swift-proxy-1.13.1-4.fc21.noarch.rpm

--- a/json-files/fedora-20-undercloud-packages.json
+++ b/json-files/fedora-20-undercloud-packages.json
@@ -1,5 +1,5 @@
 [
-  { 
+  {
     "name": "Initialization",
     "element": [
       "base",
@@ -29,7 +29,8 @@
       "keystone-1289935",
       "horizon-test-build",
       "mariadb-rdo",
-      "os-refresh-config-reboot"
+      "os-refresh-config-reboot",
+      "selinux-package-updates"
     ],
     "hook": [
       "extra-data",

--- a/scripts/instack-build-images
+++ b/scripts/instack-build-images
@@ -52,6 +52,8 @@ if [ ! -f overcloud-control.qcow2 ]; then
         -o overcloud-control \
         $NODE_DIST pip-cache boot-stack cinder-api cinder-volume os-collect-config \
         neutron-network-node dhcp-all-interfaces stackuser swift-proxy swift-storage \
+	swift-package-updates \
+	selinux-package-updates \
         baremetal \
         fedora-rdo-icehouse-repository \
         horizon \
@@ -67,6 +69,7 @@ if [ ! -f overcloud-compute.qcow2 ]; then
         -a $NODE_ARCH \
         -o overcloud-compute \
         $NODE_DIST pip-cache nova-compute nova-kvm neutron-openvswitch-agent os-collect-config \
+	selinux-package-updates \
         baremetal \
         dhcp-all-interfaces stackuser fedora-rdo-icehouse-repository \
 	stable-interface-names \
@@ -78,6 +81,7 @@ if [ ! -f overcloud-cinder-volume.qcow2 ]; then
         -a $NODE_ARCH \
         -o overcloud-cinder-volume \
         $NODE_DIST pip-cache cinder-volume neutron-openvswitch-agent os-collect-config \
+	selinux-package-updates \
         baremetal \
         dhcp-all-interfaces stackuser fedora-rdo-icehouse-repository \
 	stable-interface-names \
@@ -89,6 +93,8 @@ if [ ! -f overcloud-swift-storage.qcow2 ]; then
         -a $NODE_ARCH \
         -o overcloud-swift-storage \
         $NODE_DIST pip-cache swift-storage neutron-openvswitch-agent os-collect-config \
+	swift-package-updates \
+	selinux-package-updates \
         baremetal \
         dhcp-all-interfaces stackuser fedora-rdo-icehouse-repository \
 	stable-interface-names \


### PR DESCRIPTION
Installs SELinux and Swift packages from koji. Allows us to build
new instack overcloud images with the proper packages. When the
packages from koji are released, this change should be reverted.
