### PR TITLE
Remove instructions to pull patch for x86_64 to create-nodes

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -20,8 +20,6 @@ instack-undercloud via source
          cd instack
          git clone https://github.com/agroup/instack-undercloud
          git clone https://git.openstack.org/openstack/tripleo-incubator
-         # Pull down a needed patch for x86_64 support since discovered nodes are registered as x86_64 in Ironic.
-         pushd tripleo-incubator && git fetch https://review.openstack.org/openstack/tripleo-incubator refs/changes/03/123803/2 && git cherry-pick FETCH_HEAD && popd
 
 
 1. Complete the initial setup.

--- a/instack-sourcerc
+++ b/instack-sourcerc
@@ -47,7 +47,7 @@ if [ "$LKG" = "1" ]; then
     export DIB_REPOREF_tripleo_image_elements=5fea32ff79220fce2eb808d9b119832a98ace626
     export DIB_REPOREF_diskimage_builder=dbc60e8942ca700cd673a115a6d327af8ee41483
     export DIB_REPOREF_os_cloud_config=4a03e6b129c91a7269b6103a1f85fd011ec92c91
-    export DIB_REPOREF_tripleo_incubator=b51d5a1840b4e985b7daa334814a10590af00d53
+    export DIB_REPOREF_tripleo_incubator=c3fb309727671130a32b4c19de48ec22c8530aa1
 
     # This is set manually since swift is not part of the undercloud
     export DIB_REPOREF_swift=4dc718e8c3bd2a8bbe1f2d7a98ad03421a70217f

--- a/scripts/instack-install-undercloud-source
+++ b/scripts/instack-install-undercloud-source
@@ -93,12 +93,6 @@ if [ ! -d $INSTACK_ROOT/tripleo-incubator ]; then
         git reset --hard FETCH_HEAD
     fi
 
-
-    ## create-nodes x86_64 support
-    #
-    # https://review.openstack.org/#/c/123803/
-    git fetch https://review.openstack.org/openstack/tripleo-incubator refs/changes/03/123803/2 && git cherry-pick FETCH_HEAD
-
     popd
 
 fi


### PR DESCRIPTION
The needed patch has been merged, so we don't need to pull it in
manually anymore. Instead we update LKG to include it.
