### PR TITLE
Increase disk size for m1.tiny to 10G

### DIFF
--- a/scripts/instack-deploy-overcloud
+++ b/scripts/instack-deploy-overcloud
@@ -188,7 +188,6 @@ setup-neutron -n $NETWORK_JSON
 rm $NETWORK_JSON
 
 
-nova flavor-delete m1.tiny
-nova flavor-create m1.tiny 1 512 10 1
+nova flavor-create m1.demo 1 512 10 1
 
 echo "Overcloud Deployed"

--- a/scripts/instack-test-overcloud
+++ b/scripts/instack-test-overcloud
@@ -48,7 +48,7 @@ if ! nova keypair-show default 2>&1 1>/dev/null; then
 	tripleo user-config
 fi
 
-nova boot --key-name default --flavor m1.tiny --image user --nic net-id=$NET_ID demo
+nova boot --key-name default --flavor m1.demo --image user --nic net-id=$NET_ID demo
 
 sleep 3
 


### PR DESCRIPTION
This is so that we can use the rhel-guest-image as user image if
we want to, cause it won't fit in 2G.
