### PR TITLE
Cherry pick Dan's lsb-release patch

### DIFF
--- a/scripts/instack-install-undercloud-source
+++ b/scripts/instack-install-undercloud-source
@@ -88,6 +88,10 @@ function do_tripleo_source_installs {
         # Unset trap before dracut ramdisk build script exits
         # https://review.openstack.org/#/c/130632/
         cherry_pick diskimage-builder refs/changes/32/130632/1
+	# lsb_release url may be broken
+	# https://bzr.linuxfoundation.org/loggerhead/lsb/devel/si/download/head:/lsb_release-20060624065236-gakl5b7e37gwk5mg-12/lsb_release
+	# https://review.openstack.org/#/c/132076/
+	cherry_pick diskimage-builder refs/changes/76/132076/1
 
     fi
 


### PR DESCRIPTION
The source repository URL is currently broken and returns a
permission denied error.

Pull in Dan's patch so that package-based installs uses the
rpm instead of fetching the URL.
