### PR TITLE
cinder-volume-nfs should not be installed on block storage nodes

### DIFF
--- a/scripts/instack-build-images
+++ b/scripts/instack-build-images
@@ -104,7 +104,6 @@ export OVERCLOUD_CINDER_DIB_EXTRA_ARGS=${OVERCLOUD_CINDER_DIB_EXTRA_ARGS:-"\
 baremetal \
 base \
 cinder-lio \
-cinder-volume-nfs \
 common-venv \
 dhcp-all-interfaces \
 hosts \


### PR DESCRIPTION
The cinder-volume-nfs element is to be used on controllers, as
data traffic will not go through cinder-volume when backed by NFS
so there won't be any need for additional block storage nodes.

Block storage nodes default to LVM and should be used to take
advantage of the local storage in a pure scale-out scenario.
