### PR TITLE
Fix RabbitMQ SELinux file contexts

### DIFF
--- a/scripts/instack-install-undercloud-source
+++ b/scripts/instack-install-undercloud-source
@@ -68,6 +68,9 @@ function do_tripleo_source_installs {
         # there is cherry-pick conflict
         cherry_pick tripleo-image-elements refs/changes/08/130608/5
         cherry_pick tripleo-image-elements refs/changes/14/130714/12
+	# Fix rabbitmq SELinux file contexts
+        # https://review.openstack.org/137259
+	cherry_pick tripleo-image-elements refs/changes/59/137259/2
 
     fi
 


### PR DESCRIPTION
Runs restorecon against actual directory instead of the symlink.

This pull is only needed if tripleo-image-elements is updated and then includes this change https://github.com/openstack/tripleo-image-elements/commit/b4f59ef86bdaa09554c6741661a13a8f3fb12cba.
