### PR TITLE
Do not use maintenance mode during discovery in scripts/instack-ironic-deployment

### DIFF
--- a/scripts/instack-ironic-deployment
+++ b/scripts/instack-ironic-deployment
@@ -58,14 +58,6 @@ function register_nodes {
     register-nodes --service-host undercloud --nodes <(jq '.nodes' $NODES_JSON) 1>/dev/null
     echo "  Nodes registered."
     echo
-    echo "  Setting nodes to maintenance mode"
-    node_ids=$(ironic node-list | tail -n +4 | head -n -1 | awk -F "| " '{print $2}')
-    for node_id in $node_ids; do
-        echo -n "    Setting node $node_id to maintenance mode ... "
-        ironic node-update $node_id replace maintenance=True 1>/dev/null
-        echo "DONE."
-    done
-    echo
     ironic node-list
     echo
 }
@@ -98,7 +90,6 @@ function discover_nodes {
             sleep 15
         done
     done
-    # TODO remove nodes from maintenance mode
 }
 
 echo "Preparing for deployment..."


### PR DESCRIPTION
Maintenance mode used to be a requirement for discoverd 0.2.x, but is no longer
for 1.0.0, and actually complicates things. It is still used by Tuskar UI
but makes no sense for our new CLI.