### PR TITLE
Script to generate tripleo-overcloud-passwords using Tuskar

### DIFF
--- a/scripts/tuskar-overcloud-passwords
+++ b/scripts/tuskar-overcloud-passwords
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Generates the tripleo-overcloud-passwords file by using the data stored in
+# the environment.yaml template from Tuskar.
+#
+
+TUSKAR_PLAN_ID=$(tuskar plan-list | grep overcloud | cut -d ' ' -f 2)
+TEMP_DIR=$(mktemp)
+
+# tuskar plan-templates will create the temp directory again
+rm -rf $TEMP_DIR
+
+tuskar plan-templates -O $TEMP_DIR $TUSKAR_PLAN_ID
+
+ENV_FILE=$TEMP_DIR/environment.yaml
+
+echo "OVERCLOUD_ADMIN_PASSWORD=$(grep controller-1::AdminPassword: $ENV_FILE | cut -d " " -f 4)
+OVERCLOUD_ADMIN_TOKEN=$(grep controller-1::AdminToken: $ENV_FILE | cut -d " " -f 4)
+OVERCLOUD_CEILOMETER_PASSWORD=$(grep controller-1::CeilometerPassword: $ENV_FILE | cut -d " " -f 4)
+OVERCLOUD_CEILOMETER_SECRET=$(grep controller-1::CeilometerMeteringSecret: $ENV_FILE | cut -d " " -f 4)
+OVERCLOUD_CINDER_PASSWORD=$(grep controller-1::CinderPassword: $ENV_FILE | cut -d " " -f 4)
+OVERCLOUD_GLANCE_PASSWORD=$(grep controller-1::GlancePassword: $ENV_FILE | cut -d " " -f 4)
+OVERCLOUD_HEAT_PASSWORD=$(grep controller-1::HeatPassword: $ENV_FILE | cut -d " " -f 4)
+OVERCLOUD_NEUTRON_PASSWORD=$(grep controller-1::NeutronPassword: $ENV_FILE | cut -d " " -f 4)
+OVERCLOUD_NOVA_PASSWORD=$(grep controller-1::NovaPassword: $ENV_FILE | cut -d " " -f 4)
+OVERCLOUD_SWIFT_HASH=$(grep controller-1::SwiftHashSuffix: $ENV_FILE | cut -d " " -f 4)
+OVERCLOUD_SWIFT_PASSWORD=$(grep  controller-1::SwiftPassword: $ENV_FILE | cut -d " " -f 4)" > tripleo-overcloud-passwords
+
+rm -rf $TEMP_DIR


### PR DESCRIPTION
Tuskar-UI deployed overclouds don't generate the passwords file.

The passwords file is needed by instack-test-overcloud.

Run the script an other steps (https://trello.com/c/AMJeIJei/43-test-compute-control-object-storage-block-storage-through-the-ui-tripleorhos6) in instack-deploy-overcloud manually
before running instack-test-overcloud against a Tuskar-UI deployed
overcloud.
