### PR TITLE
Add jq to openstack-full element

### DIFF
--- a/elements/openstack-full/install.d/10-openstack-full
+++ b/elements/openstack-full/install.d/10-openstack-full
@@ -6,4 +6,4 @@ set -eux
 sed -i -e 's/=enforcing/=permissive/g' /etc/selinux/config
 
 yum install -y --nogpg /opt/stack/files/puppet-release.rpm
-yum install -y --nogpg puppet augeas rabbitmq-server openstack-keystone keepalived haproxy mariadb-galera-server ntp memcached mongodb-server xinetd mongodb grub2 bind-utils openstack-swift-account openstack-swift-container openstack-swift-object openstack-dashboard
+yum install -y --nogpg puppet augeas rabbitmq-server openstack-keystone keepalived haproxy mariadb-galera-server ntp memcached mongodb-server xinetd mongodb grub2 bind-utils openstack-swift-account openstack-swift-container openstack-swift-object openstack-dashboard jq


### PR DESCRIPTION
This enables us to more easily query config-drive metadata to extract
discovery data at deployment time.