### PR TITLE
Add deployment option to instack-ironic-deployment

### DIFF
--- a/heat-templates/ironic-deployment.yaml
+++ b/heat-templates/ironic-deployment.yaml
@@ -1,0 +1,50 @@
+heat_template_version: 2014-10-16
+
+parameters:
+  config_drive_label:
+    type: string
+    default: config-2
+
+  discovery_metadata_key:
+    type: string
+    default: hardware
+
+  flavor:
+    type: string
+    default: baremetal
+
+  image:
+    type: string
+    default: openstack-full
+
+  key_name:
+    type: string
+    default: default
+
+  node_count:
+    type: number
+    default: 1
+
+resources:
+  servers:
+    type: OS::Heat::ResourceGroup
+    properties:
+      count: {get_param: node_count}
+      resource_def:
+        type: OS::Nova::Server
+        properties:
+          flavor: {get_param: flavor}
+          image: {get_param: image}
+          key_name: {get_param: key_name}
+          config_drive: True
+          user_data:
+            str_replace:
+              template: |
+                #!/bin/bash -v
+                # Mount the config drive and extract the discovery data
+                mount /dev/disk/by-label/disklabel /mnt
+                jq -r ".metadata_key" /mnt/openstack/latest/meta_data.json > /tmp/discovery.json
+    
+              params:
+                disklabel: { get_param: config_drive_label }
+                metadata_key: { get_param: discovery_metadata_key }

--- a/scripts/instack-ironic-deployment
+++ b/scripts/instack-ironic-deployment
@@ -30,7 +30,7 @@ function show_options () {
     exit $1
 }
 
-TEMP=$(getopt -o ,h -l,register-nodes,nodes-json:,discover-nodes,help -o,x,h -n $SCRIPT_NAME -- "$@")
+TEMP=$(getopt -o ,h -l,register-nodes,nodes-json:,discover-nodes,deploy-nodes,help -o,x,h -n $SCRIPT_NAME -- "$@")
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 
 # Note the quotes around `$TEMP': they are essential!
@@ -39,12 +39,14 @@ eval set -- "$TEMP"
 REGISTER_NODES=
 NODES_JSON=
 DISCOVER_NODES=
+DEPLOY_NODES=
 
 while true ; do
     case "$1" in
         --register-nodes) REGISTER_NODES="1"; shift 1;;
         --nodes-json) NODES_JSON="$2"; shift 2;;
         --discover-nodes) DISCOVER_NODES="1"; shift 1;;
+        --deploy-nodes) DEPLOY_NODES="1"; shift 1;;
         -x) set -x; shift 1;;
         -h | --help) show_options 0;;
         --) shift ; break ;;
@@ -92,6 +94,13 @@ function discover_nodes {
     done
 }
 
+function deploy_nodes {
+    DEPLOY_HEAT_TEMPLATE=${DEPLOY_HEAT_TEMPLATE:-"$HOME/instack-undercloud/heat-templates/ironic-deployment.yaml"}
+    DEPLOY_COUNT=${DEPLOY_COUNT:-"4"}
+    DEPLOY_NAME=${DEPLOY_NAMET:-"ironic-disover"}
+    heat stack-create $DEPLOY_NAME -f $DEPLOY_HEAT_TEMPLATE -P "node_count=$DEPLOY_COUNT"
+}
+
 echo "Preparing for deployment..."
 
 if [ "$REGISTER_NODES" = 1 ]; then
@@ -103,3 +112,9 @@ if [ "$DISCOVER_NODES" = 1 ]; then
 fi
 
 echo "Prepared."
+
+if [ "$DEPLOY_NODES" = 1 ]; then
+    echo "Deploying..."
+    deploy_nodes
+    echo "Deployed."
+fi


### PR DESCRIPTION
Adds a new --deploy-nodes option, which deploys a heat stack
containing some baremetal servers, with some initial minimal
logic which proves the ironic config injection works.

Note the template will probably need updating for the top-level
metadata key when the real discovery data is injected, this
expects dummy data, added like this:

ironic node-update <id> add extra/configdrive_metadata='{"hardware": {"foo": "bar"}}'