### PR TITLE
Add external routing

### DIFF
--- a/elements/undercloud-stack-config/os-apply-config/var/opt/undercloud-stack/masquerade
+++ b/elements/undercloud-stack-config/os-apply-config/var/opt/undercloud-stack/masquerade
@@ -10,6 +10,7 @@ NETWORK={{.}}
 # Workaround iptables not permitting two -d parameters in one call.
 iptables -t nat -A BOOTSTACK_MASQ_NEW -s $NETWORK -d 192.168.122.1 -j RETURN
 iptables -t nat -A BOOTSTACK_MASQ_NEW -s $NETWORK ! -d $NETWORK -j MASQUERADE
+iptables -t nat -A POSTROUTING -s $NETWORK -o eth0 -j MASQUERADE
 {{/bootstack.masquerade_networks}}
 # Link it in.
 iptables -t nat -I POSTROUTING -j BOOTSTACK_MASQ_NEW
@@ -19,4 +20,6 @@ iptables -t nat -D POSTROUTING -j BOOTSTACK_MASQ || true
 iptables -t nat -X BOOTSTACK_MASQ || true
 # Rename the new chain into permanence.
 iptables -t nat -E BOOTSTACK_MASQ_NEW BOOTSTACK_MASQ
+# remove forwarding rule (fixes bug 1183099)
+iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited
 


### PR DESCRIPTION
When setting up instack-undercloud within a virtual environment, the
default iptables rules don't allow the overcloud nodes to route
externally.  This patch adds a rule and deletes a rule that allows
the overcloud nodes to route and ping external dns addresses.